### PR TITLE
Fix quoting map literal example

### DIFF
--- a/src/posts/2021/04/the_elixir_ast.md
+++ b/src/posts/2021/04/the_elixir_ast.md
@@ -171,7 +171,7 @@ For example, the following map:
 ```
 Is represented by the call:
 ```elixir
-{:%{}, [], [foo, :bar]}
+{:%{}, [], [foo: :bar]}
 ```
 The same goes for tuples of sizes other than 2:
 ```elixir


### PR DESCRIPTION
I enjoying reading this, thanks for writing it.
Seems there's a typo in the quoting map example:

```
iex> quote do
...> %{foo: :bar}
...> end
{:%{}, [], [foo: :bar]}
```

I look forward to your next article, as I'd like to make credo "auto-fix" some of the issues it finds.