### PR TITLE
no need to use [] around ignored _meta

### DIFF
--- a/src/posts/2021/04/the_elixir_ast_typedstruct.md
+++ b/src/posts/2021/04/the_elixir_ast_typedstruct.md
@@ -115,13 +115,13 @@ defmacro typedstruct(do: ast) do
   fields_data = Enum.map(fields_ast, &get_field_data/1)
 end
 
-defp get_field_data({:field, [], [name, typespec]}) do
+defp get_field_data({:field, _meta, [name, typespec]}) do
   # In this case the options were not provided,
   # so we set them to the empty list and process
   # it again
   get_field_data({:field, [], [name, typespec, []]})
 end
-defp get_field_data({:field, [], [name, typespec, opts]}) do
+defp get_field_data({:field, _meta, [name, typespec, opts]}) do
   default = Keyword.get(opts, :default)
   enforced? = Keyword.get(opts, :enforced?, false)
 
@@ -241,10 +241,10 @@ defmodule TypedStruct do
     end
   end
 
-  defp get_field_data({:field, [], [name, typespec]}) do
-    get_field_data({:field, [], [name, typespec, []]})
+  defp get_field_data({:field, _meta, [name, typespec]}) do
+    get_field_data({:field, _meta, [name, typespec, []]})
   end
-  defp get_field_data({:field, [], [name, typespec, opts]}) do
+  defp get_field_data({:field, _meta, [name, typespec, opts]}) do
     default = Keyword.get(opts, :default)
     enforced? = Keyword.get(opts, :enforced?, false)
 

--- a/src/posts/2021/04/the_elixir_ast_typedstruct.md
+++ b/src/posts/2021/04/the_elixir_ast_typedstruct.md
@@ -242,7 +242,7 @@ defmodule TypedStruct do
   end
 
   defp get_field_data({:field, _meta, [name, typespec]}) do
-    get_field_data({:field, _meta, [name, typespec, []]})
+    get_field_data({:field, [], [name, typespec, []]})
   end
   defp get_field_data({:field, _meta, [name, typespec, opts]}) do
     default = Keyword.get(opts, :default)


### PR DESCRIPTION
this function get_field_data/1 produce compile error because you match on a non-empty list with an empty list

```
== Compilation error in file lib/report.ex ==
** (FunctionClauseError) no function clause matching in TypedStruct.get_field_data/1    
    
    The following arguments were given to TypedStruct.get_field_data/1:
    
        # 1
        {:field, [], [:message, {{:., [line: 9], [{:__aliases__, [line: 9], [:String]}, :t]}, [line: 9], []}, []]}
    
    lib/typed_struct.ex:40: TypedStruct.get_field_data/1
    (elixir 1.13.0) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.13.0) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    expanding macro: TypedStruct.typedstruct/1
    lib/report.ex:6: Report (module)
```
